### PR TITLE
Remove unused entry_counts attribute in Day2

### DIFF
--- a/day2/lib/day2.rb
+++ b/day2/lib/day2.rb
@@ -1,6 +1,6 @@
 module Day2
   class PasswordList
-    attr_accessor :password_list, :entry_counts
+    attr_accessor :password_list
 
     def initialize(password_list)
       @password_list = password_list


### PR DESCRIPTION
So interesting that there is no signal about this unused attribute unless you run a linter or Rubocop.

🤷